### PR TITLE
feat: rename `type_hash` to `scope_hash`

### DIFF
--- a/src/session/interface.cairo
+++ b/src/session/interface.cairo
@@ -39,10 +39,19 @@ struct SessionToken {
     proofs: Span<Span<felt252>>,
 }
 
+/// @param scope_hash Commitment computed as `poseidon(domain_separator_hash, type_hash)`
+/// @param typed_data_hash Encoded data for the primary type as a single `felt252`
 #[derive(Drop, Serde, Copy)]
 struct TypedData {
-    type_hash: felt252,
+    scope_hash: felt252,
     typed_data_hash: felt252,
+}
+
+#[derive(Drop, Serde, Copy)]
+struct DetailedTypedData {
+    domain_hash: felt252,
+    type_hash: felt252,
+    params: Span<felt252>,
 }
 
 #[derive(Drop, Serde, Copy)]

--- a/src/session/session_hash.cairo
+++ b/src/session/session_hash.cairo
@@ -31,14 +31,15 @@ const SESSION_TYPE_HASH_REV_1: felt252 =
         "\"Session\"(\"Expires At\":\"timestamp\",\"Allowed Methods\":\"merkletree\",\"Metadata\":\"string\",\"Session Key\":\"felt\")"
     );
 const DATA_TYPE_HASH_REV_1: felt252 =
-    selector!("\"Allowed Type\"(\"Type Hash\":\"felt\", \"Typed Data Hash\":\"felt\")");
+    selector!("\"Allowed Type\"(\"Scope Hash\":\"felt\",\"Typed Data Hash\":\"felt\")");
 
 const ALLOWED_METHOD_HASH_REV_1: felt252 =
     selector!(
         "\"Allowed Method\"(\"Contract Address\":\"ContractAddress\",\"selector\":\"selector\")"
     );
 
-const ALLOWED_DATA_TYPE_HASH_REV_1: felt252 = selector!("\"Allowed Type\"(\"Type Hash\":\"felt\")");
+const ALLOWED_DATA_TYPE_HASH_REV_1: felt252 =
+    selector!("\"Allowed Type\"(\"Scope Hash\":\"felt\")");
 
 impl MerkleLeafHash of IMerkleLeafHash<Call> {
     fn get_merkle_leaf(self: @Call) -> felt252 {
@@ -50,7 +51,7 @@ impl MerkleLeafHash of IMerkleLeafHash<Call> {
 
 impl MerkleLeafHashTypedData of IMerkleLeafHash<TypedData> {
     fn get_merkle_leaf(self: @TypedData) -> felt252 {
-        poseidon_hash_span(array![ALLOWED_DATA_TYPE_HASH_REV_1, *self.type_hash].span())
+        poseidon_hash_span(array![ALLOWED_DATA_TYPE_HASH_REV_1, *self.scope_hash].span())
     }
 }
 
@@ -85,7 +86,7 @@ impl StructHashTypedData of IStructHashRev1<TypedData> {
     fn get_struct_hash_rev_1(self: @TypedData) -> felt252 {
         let self = *self;
         poseidon_hash_span(
-            array![DATA_TYPE_HASH_REV_1, self.type_hash, self.typed_data_hash].span()
+            array![DATA_TYPE_HASH_REV_1, self.scope_hash, self.typed_data_hash].span()
         )
     }
 }


### PR DESCRIPTION
To signal that this field now takes `domain_hash` into account as `poseidon(domain_hash, type_hash)`.

Also fixes the extra whitespace in `DATA_TYPE_HASH_REV_1`.

Also adds a new `DetailedTypedData` type to be embedded in SNIP-12-compatible session typed data signatures.